### PR TITLE
Fix single brick problem for gluster_vol

### DIFF
--- a/lib/puppet/provider/glusterfs_vol/glusterfs_vol.rb
+++ b/lib/puppet/provider/glusterfs_vol/glusterfs_vol.rb
@@ -75,6 +75,9 @@ Puppet::Type.type(:glusterfs_vol).provide(:glusterfs) do
     end
 
     missing_brick = []
+    unless resource[:brick].kind_of? Array
+      resource[:brick] = [ resource[:brick] ]
+    end
     resource[:brick].map do |brick|
       if not volinfo =~ /Brick\d+:\s#{Regexp.escape(brick)}/ 
         self.debug "#{brick} is missing from the volume"


### PR DESCRIPTION
If volume has single brick then `resource[:brick]` is of type String. This breaks `map()` call. This request fixes this issue.